### PR TITLE
React native 0.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-NOTE: There's not much point to this component now the built in WebView has more features
+NOTE: There's not much point to this component now the built in WebView has more features. You might want to check out my ([safe-html](http://github.com/almost/safe-html)) library though if you want to make your untrusted HTML safe.
 
 # react-native-html-webview
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+NOTE: There's not much point to this component now the built in WebView has more features
+
 # react-native-html-webview
 
 Display (possibly untrusted) HTML using a UIWebView in React Native.

--- a/index.ios.js
+++ b/index.ios.js
@@ -27,7 +27,7 @@ var NativeHTMLWebView = requireNativeComponent('AIBHTMLWebView', _HTMLWebView);
 var HTMLWebView = React.createClass({
   propTypes: {
     html: PropTypes.string.isRequired,
-    makeSafe: PropTypes.oneOfType([PropTypes.object, PropTypes.boolean]),
+    makeSafe: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
     onLink: PropTypes.func,
     style: View.propTypes.style,
     // Should this view adjust its height automatically to show its

--- a/index.ios.js
+++ b/index.ios.js
@@ -27,7 +27,7 @@ var NativeHTMLWebView = requireNativeComponent('AIBHTMLWebView', _HTMLWebView);
 var HTMLWebView = React.createClass({
   propTypes: {
     html: PropTypes.string.isRequired,
-    makeSafe: PropTypes.object,
+    makeSafe: PropTypes.oneOfType([PropTypes.object, PropTypes.boolean]),
     onLink: PropTypes.func,
     style: View.propTypes.style,
     // Should this view adjust its height automatically to show its

--- a/index.ios.js
+++ b/index.ios.js
@@ -2,12 +2,11 @@
 // remove javascript and any other dangerous tags. Link clicks will
 // generate events but won't automatically change what is displayed.
 
-var React = require('react-native');
+var React = require('react');
 var {
   View,
-  PropTypes,
   requireNativeComponent
-} = React;
+} = require('react-native');
 
 var safeHtml = require('safe-html');
 var _ = require('underscore');
@@ -15,8 +14,8 @@ var _ = require('underscore');
 
 var _HTMLWebView = React.createClass({
   propTypes: {
-    html: PropTypes.string,
-    autoHeight: PropTypes.bool
+    html: React.PropTypes.string,
+    autoHeight: React.PropTypes.bool
   },
   render: function () {
     return <NativeHTMLWebView {...this.props}/>;
@@ -26,13 +25,13 @@ var NativeHTMLWebView = requireNativeComponent('AIBHTMLWebView', _HTMLWebView);
 
 var HTMLWebView = React.createClass({
   propTypes: {
-    html: PropTypes.string.isRequired,
-    makeSafe: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
-    onLink: PropTypes.func,
+    html: React.PropTypes.string.isRequired,
+    makeSafe: React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.bool]),
+    onLink: React.PropTypes.func,
     style: View.propTypes.style,
     // Should this view adjust its height automatically to show its
     // complete content
-    autoHeight: PropTypes.bool
+    autoHeight: React.PropTypes.bool
   },
 
   shouldComponentUpdate: function (nextProps, nextState) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-html-webview",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Display (possibly untrusted) HTML using a UIWebView in React Native.",
   "main": "index.ios.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-html-webview",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Display (possibly untrusted) HTML using a UIWebView in React Native.",
   "main": "index.ios.js",
   "scripts": {


### PR DESCRIPTION
This brings this package up-to-date with the original almost/react-native-html-webview, allowing it to be used with RN >= 0.26
